### PR TITLE
Add Telecom use cases

### DIFF
--- a/draft-ietf-spice-use-cases.md
+++ b/draft-ietf-spice-use-cases.md
@@ -31,6 +31,24 @@ author:
     organization: "Tradeverifyd"
     email: brent.zundel@gmail.com
 
+contributor:
+  -
+    fullname: Yurong Song
+    organization: Huawei
+    email: songyurong1@huawei.com
+  -
+    fullname: Lun Li
+    organization: Huawei
+    email: lilun20@huawei.com
+  -
+    fullname: Donghui Wang
+    organization: Huawei
+    email: wangdonghui124@huawei.com
+  -
+    fullname: Fei Liu
+    organization: Huawei
+    email: liufei19@huawei.com
+
 normative:
 
 informative:
@@ -270,4 +288,6 @@ This document has no IANA actions.
 # Acknowledgments
 {:numbered="false"}
 
-TODO acknowledge.
+The authors would like to thank the following individuals for their
+contributions to this specification:
+Yurong Song, Lun Li, Donghui Wang, Fei Liu


### PR DESCRIPTION
This is an attempt to add "2.1.2.  Introduce Attributes into Telecom Network" from https://www.ietf.org/archive/id/draft-song-spice-telecom-usecases-00.txt into this document.
